### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create, :edit, :update]
-  before_action :set_item, only: [:show, :edit, :update]
-  before_action :redirect_unless_author, only: [:edit, :update]
+  before_action :authenticate_user!, only: [:new, :create, :edit, :update, :destroy]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
+  before_action :redirect_unless_author, only: [:edit, :update, :destroy]
 
   def index
     @items = Item.all.order('created_at DESC')
@@ -32,6 +32,11 @@ class ItemsController < ApplicationController
     else
       render :edit
     end
+  end
+
+  def destroy
+    @item.destroy
+    redirect_to root_path, notice: '商品が正常に削除されました。'
   end
 
   private

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,7 +27,7 @@
     <% if user_signed_in? && current_user.id == @item.user_id %>
       <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
       <p class="or-text">or</p>
-      <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+      <%= link_to "削除", item_path(@item), data: { turbo_method: :delete }, class: "item-destroy" %>
     <% end %>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一でなければ、購入ボタンを表示 %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items, only: [:index, :show, :edit, :new, :create, :update]
+  resources :items
 end


### PR DESCRIPTION
### What
- ログイン状態の場合にのみ、自身が出品した商品情報を削除できる機能を追加しました。
- 削除が完了したら、トップページに遷移する機能を追加しました。

### Why
- **セキュリティの向上**: ログイン状態のユーザーのみが自身の商品情報を削除できるようにすることで、不正なユーザーによる意図しない商品情報の削除を防ぐためです。
- **ユーザー体験の改善**: 商品情報の削除後にトップページへ自動的に遷移させることで、ユーザーが次のアクションを取りやすくし、アプリケーションの使い勝手を向上させるためです。

### 検証動画
ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
[動画1](https://gyazo.com/ebe5d380674c2c98a6cba33d48f1d991)
