### PR TITLE
Ordersレコードが二重で発火する問題解消

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -51,7 +51,6 @@ class OrdersController < ApplicationController
 
   def process_payment
     if @purchase_form.save
-      @item.create_order(user: current_user) # Orderを作成して商品を売却済みにする
       redirect_to root_path, notice: '商品の購入が完了しました。'
     else
       render :index

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,9 +2,6 @@ Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
   resources :items do
-    member do
-      patch :sell  # ここにsellアクションへのルーティングを追加
-    end
     resources :orders, only: [:index, :show, :create] 
   end
 end


### PR DESCRIPTION
## What
Ordersレコードが二重で発火する問題を解消するためにコードを修正した。

## Why
`OrdersController`の`process_payment`メソッド内で、`PurchaseForm`の`save`メソッドによって既に注文が作成されているにも関わらず、重複して`Order`を作成してしまっていた。これにより、不要なレコードがデータベースに追加され、注文の二重カウントという問題が生じていた。`process_payment`内の`@item.create_order(user: current_user)`を削除することで、重複作成を防ぎ、問題を解消することができた。
